### PR TITLE
Github Actions - Create CI Pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,6 +89,11 @@ jobs:
           recreate: true
           path: coverage_report.html
 
-      - name: Write to Job Summary
+      - name: Install Links
+        # This is required to correctly display the HTML of the Coverage Report
+        if: success() || failure() # Always run, including if earlier steps failed
+        run: sudo apt-get install links
+
+      - name: Write Coverage Report to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
         run: links coverage_report.html >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,13 +47,21 @@ jobs:
           ref: gh-pages
           path: public
 
+      - name: Cache Go Install
+        uses: actions/cache@v3
+        id: go-cache-step
+        with:
+          path: '**/usr/local/go'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
+
       - name: Install Go
+        if: steps.go-cache-step.outputs.cache-hit != 'true'
         uses: actions/setup-go@v3
         with:
           go-version-file: './go.mod'
           cache: true # Caches Go dependencies
 
-      - name: Get Previously Cache Dependencies
+      - name: Buffalo - Get Previously Cached Install & Dependencies
         # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
         id: buffalo-cache-step
         uses: actions/cache@v3

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,9 +83,8 @@ jobs:
           path: ./coverage_report.html
 
       - name: Add Coverage PR Comment
-        if: success() || failure() # Always run, including if earlier steps failed
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && (success() || failure())
         with:
           recreate: true
           path: coverage_report.html

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,6 +89,7 @@ jobs:
           recreate: true
           path: coverage_report.html
 
+      '''
       - name: Install Pandoc
         if: success() || failure() # Always run, including if earlier steps failed
         # required to convert the report from HTML to Markdown for pretty embedding in the Job Summary
@@ -97,7 +98,8 @@ jobs:
       - name: Convert Coverage Report HTML to Markdown
         if: success() || failure() # Always run, including if earlier steps failed
         run: pandoc --from html --to markdown coverage_report.html -o coverage_report.md
+      '''
 
       - name: Write Coverage Report to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: cat coverage_report.md >> $GITHUB_STEP_SUMMARY
+        run: coverage_report.html >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,18 +89,12 @@ jobs:
           recreate: true
           path: coverage_report.html
 
-
-      - name: Write Coverage Report to Github Actions Job Summary
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: coverage_report.html >> $GITHUB_STEP_SUMMARY
-
       - name: Move Report HTML to directory to publish on Github Pages
         if: success() || failure() # Always run, including if earlier steps failed
         run: |
           mkdir public
-          
+          mv coverage_report.html ./public/index.html
           cd public
-          touch index.html
 
       - name: Deploy
         if: success() || failure() # Always run, including if earlier steps failed
@@ -108,3 +102,7 @@ jobs:
         with:
           folder: public
           branch: gh-pages
+
+      - name: Write Coverage Report to Github Actions Job Summary
+        if: success() || failure() # Always run, including if earlier steps failed
+        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/#file0" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,16 +89,6 @@ jobs:
           recreate: true
           path: coverage_report.html
 
-      '''
-      - name: Install Pandoc
-        if: success() || failure() # Always run, including if earlier steps failed
-        # required to convert the report from HTML to Markdown for pretty embedding in the Job Summary
-        run: sudo apt-get install pandoc
-
-      - name: Convert Coverage Report HTML to Markdown
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: pandoc --from html --to markdown coverage_report.html -o coverage_report.md
-      '''
 
       - name: Write Coverage Report to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,50 +69,7 @@ jobs:
       - name: Install Buffalo pop plugin
         run: buffalo plugins install
 
-      - name: Buffalo Pop - Create Database
-        run: buffalo pop create -a
-
-      - name: Buffalo Pop - Apply Migrations
-        run: buffalo pop migrate
-
-      - name: Buffalo Build
-        run: buffalo build
-
-      - name: Buffalo Tests / Generate Coverage Report
-        run: buffalo test -coverprofile=c.out ./...
-
-      - name: Convert Test Coverage Report to be Human Readable
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: go tool cover -html c.out -o coverage_report.html
-
-      - name: Upload Test Coverage Report as Artifact
-        if: success() || failure() # Always run, including if earlier steps failed
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-coverage-report
-          path: ./coverage_report.html
-
-      - name: Add Test Coverage Pull Request Comment (if on PR)
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request' && (success() || failure())
-        with:
-          recreate: true
-          path: coverage_report.html
-
-      - name: Move Test Coverage Report HTML to directory to publish on 'gh-pages' Branch (Github Pages)
-        if: success() || failure() # Always run, including if earlier steps failed
+      - name: test
         run: |
-          mkdir -p public/${{  github.run_number  }}
-          mv coverage_report.html ./public/${{  github.run_number  }}/index.html
-
-      - name: Add Test Coverage Report Artifact to 'gh-pages' Branch (Github Pages)
-        if: success() || failure() # Always run, including if earlier steps failed
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: public
-          branch: gh-pages
-          force: false
-
-      - name: Add Test Coverage Report Link to Github Actions Job Summary
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: echo -e "Test Coverage Report https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' Github Actions Hob has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY
+          pwd
+          ls

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,3 +73,9 @@ jobs:
         run: |
           pwd
           ls
+        
+      - name: plugin-path
+        run: echo "$BUFFALO_PLUGIN_PATH"
+
+      - name: gopath-bin
+        run: echo "$GOPATH/bin"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{  env.go-version  }}
+          cache: true
         
       - name: Install Buffalo
         run: |
@@ -77,31 +78,31 @@ jobs:
       - name: Buffalo Tests / Generate Coverage Report
         run: buffalo test -coverprofile=c.out ./...
 
-      - name: Convert Coverage Report to be Human Readable
+      - name: Convert Test Coverage Report to be Human Readable
         if: success() || failure() # Always run, including if earlier steps failed
         run: go tool cover -html c.out -o coverage_report.html
 
-      - name: Upload Coverage Report as Artifact
+      - name: Upload Test Coverage Report as Artifact
         if: success() || failure() # Always run, including if earlier steps failed
         uses: actions/upload-artifact@v3
         with:
           name: test-coverage-report
           path: ./coverage_report.html
 
-      - name: Add Coverage PR Comment
+      - name: Add Test Coverage Pull Request Comment (if on PR)
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request' && (success() || failure())
         with:
           recreate: true
           path: coverage_report.html
 
-      - name: Move Report HTML to directory to publish on Github Pages
+      - name: Move Test Coverage Report HTML to directory to publish on 'gh-pages' Branch (Github Pages)
         if: success() || failure() # Always run, including if earlier steps failed
         run: |
           mkdir -p public/${{  github.run_number  }}
           mv coverage_report.html ./public/${{  github.run_number  }}/index.html
 
-      - name: Deploy
+      - name: Add Test Coverage Report Artifact to 'gh-pages' Branch (Github Pages)
         if: success() || failure() # Always run, including if earlier steps failed
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -109,6 +110,6 @@ jobs:
           branch: gh-pages
           force: false
 
-      - name: Add Coverage Report Link to Github Actions Job Summary
+      - name: Add Test Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
         run: echo -e "Test Coverage Report https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' Github Actions Hob has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,4 +104,4 @@ jobs:
 
       - name: Add Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/#file0" >> $GITHUB_STEP_SUMMARY
+        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/${{  github.run_number  }}/#file0" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -76,6 +76,6 @@ jobs:
 
       - name: Upload Coverage Report as Artifact
         uses: actions/upload-artifact@v3
-          with:
-            name: test-coverage-report
-            path: ./coverage_report.html
+        with:
+          name: test-coverage-report
+          path: ./coverage_report.html

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -99,11 +99,11 @@ jobs:
         run: |
           mkdir public
           mv coverage_report.html ./public/coverage_report.html
+          cd public
+          ls
 
-      - name: "Publish test results"
-        if: success() || failure() # Always run, including if earlier steps failed
-        uses: peaceiris/actions-gh-pages@v3.9.2
-        with: 
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          keep_files: true
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: public
+          branch: gh-pages

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,9 +69,9 @@ jobs:
         run: buffalo build
 
       - name: Buffalo Tests
-        run: buffalo test
+        run: buffalo test -coverprofile=CoverageReport.out
 
       - name: Coverage Report
-        # Always run, including if the previous 'Buffalo Tests' step fails
+        # Always run. Including if the previous 'tests' step fails
         if: success() || failure()
-        run: echo 'rawr!'
+        run: cat CoverageReport.out

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,7 +56,9 @@ jobs:
         id: buffalo-cache-step
         uses: actions/cache@v3
         with:
-          path: '/usr/local/bin/buffalo'
+          path: |
+            '/usr/local/bin/buffalo'
+            '/home/runner/go/bin/buffalo-pop'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo
@@ -67,6 +69,7 @@ jobs:
           sudo mv buffalo /usr/local/bin/buffalo
 
       - name: Install Buffalo pop plugin
+        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
         run: buffalo plugins install
 
       - name: bin

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Checkout tools repo
+      - name: Checkout GH Pages
         uses: actions/checkout@v3
         with:
           repository: ${{  github.repository_owner  }}/gh-pages

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,6 +75,9 @@ jobs:
           pwd
           ls
 
+      - name: find
+        run: find ~/ -type f -name "buffalo-pop"
+
 
       - name: test
         run: buffalo plugins list

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -98,9 +98,9 @@ jobs:
         if: success() || failure() # Always run, including if earlier steps failed
         run: |
           mkdir public
-          mv coverage_report.html ./public/index.html
+          
           cd public
-          ls
+          touch index.html
 
       - name: Deploy
         if: success() || failure() # Always run, including if earlier steps failed

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -92,9 +92,8 @@ jobs:
       - name: Move Report HTML to directory to publish on Github Pages
         if: success() || failure() # Always run, including if earlier steps failed
         run: |
-          mkdir public
-          mv coverage_report.html ./public/index.html
-          cd public
+          mkdir -p public/${{  github.run_number  }}
+          mv coverage_report.html ./public/${{  github.run_number  }}/index.html
 
       - name: Deploy
         if: success() || failure() # Always run, including if earlier steps failed
@@ -103,6 +102,6 @@ jobs:
           folder: public
           branch: gh-pages
 
-      - name: Write Coverage Report to Github Actions Job Summary
+      - name: Add Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
         run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/#file0" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout GH Pages
         uses: actions/checkout@v3
         with:
-          repository: ${{  github.repository_owner  }}/gh-pages
+          ref: gh-pages
           path: public
 
       - name: Install Go

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -101,7 +101,8 @@ jobs:
         with:
           folder: public
           branch: gh-pages
+          force: false
 
       - name: Add Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/${{  github.run_number  }}/#file0" >> $GITHUB_STEP_SUMMARY
+        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/${{  github.run_number  }}/#file0  (NOTE - This link will not work until the 'pages build and deployment' job has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -111,4 +111,4 @@ jobs:
 
       - name: Add Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: echo -e "Coverage Report Link https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' job has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY
+        run: echo -e "Test Coverage Report https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' Github Actions Hob has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -103,6 +103,7 @@ jobs:
           ls
 
       - name: Deploy
+        if: success() || failure() # Always run, including if earlier steps failed
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: public

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,9 +15,7 @@ env:
   PGPASSWORD: paphos
 
 jobs:
-  # Label of the container job
   paphos-backend-tests:
-    # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
 
     # PostgreSQL as Service Container - Directly on the Runner without a Container, since a container seems to cause issues with buffalo install
@@ -91,15 +89,13 @@ jobs:
         # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
         uses: actions/cache/save@v3
         with:
-          path: '/usr/local/bin/buffalo'
+          path: '~/usr/local/bin/buffalo'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
 
       - name: Go Save
         uses: actions/cache/save@v3
         with:
-          path: |
-            '/usr/local/go'
-            '$GOPATH/pkg/mod'
+          path: '~/usr/local/go'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
       
       - name: Buffalo Pop - Create Database

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,14 +91,14 @@ jobs:
         # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
         uses: actions/cache/save@v3
         with:
-          path: '**/usr/local/bin/buffalo'
+          path: '/usr/local/bin/buffalo'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
 
       - name: Go Save
         uses: actions/cache/save@v3
         with:
           path: |
-            '**/usr/local/go'
+            '/usr/local/go'
             '$GOPATH/pkg/mod'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
       

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,9 +53,7 @@ jobs:
 
       - name: test
         run: |
-          pwd
-          ls
-          cd /usr/
+          cd /usr/local
           pwd
           ls
  

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,85 +51,11 @@ jobs:
           go-version-file: './go.mod'
           cache: true
 
-      - name: Buffalo - Get Previously Cached Install & Dependencies
-        # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
-        id: buffalo-cache-step
-        uses: actions/cache@v3
-        with:
-          path: '/home/runner/bin/buffalo'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
-        
-      - name: Install Buffalo
-        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
+      - name: test
         run: |
-          wget https://github.com/gobuffalo/cli/releases/download/v0.18.13/buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
-          tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
-          sudo mv buffalo /usr/local/bin/buffalo
-          
-      - name: Install Buffalo pop plugin
-        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
-        run: buffalo plugins install
-
-      - name: Go Version
-        run: go version
-
-      - name: Buffalo Version
-        run: buffalo version
-
-      - name: Buffalo - save
-        # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
-        uses: actions/cache/save@v3
-        with:
-          path: '${{ github.workspace }}/usr/local/bin/buffalo'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
-
-      - name: Go Save
-        uses: actions/cache/save@v3
-        with:
-          path: '${{ github.workspace }}/usr/local/go'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
-      
-      - name: Buffalo Pop - Create Database
-        run: buffalo pop create -a
-
-      - name: Buffalo Build
-        run: buffalo build
-
-      - name: Buffalo Tests / Generate Coverage Report
-        run: buffalo test -coverprofile=c.out ./...
-
-      - name: Convert Test Coverage Report to be Human Readable
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: go tool cover -html c.out -o coverage_report.html
-
-      - name: Upload Test Coverage Report as Artifact
-        if: success() || failure() # Always run, including if earlier steps failed
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-coverage-report
-          path: ./coverage_report.html
-
-      - name: Add Test Coverage Pull Request Comment (if on PR)
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request' && (success() || failure())
-        with:
-          recreate: true
-          path: coverage_report.html
-
-      - name: Move Test Coverage Report HTML to directory to publish on 'gh-pages' Branch (Github Pages)
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: |
-          mkdir -p public/${{  github.run_number  }}
-          mv coverage_report.html ./public/${{  github.run_number  }}/index.html
-
-      - name: Add Test Coverage Report Artifact to 'gh-pages' Branch (Github Pages)
-        if: success() || failure() # Always run, including if earlier steps failed
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: public
-          branch: gh-pages
-          force: false
-
-      - name: Add Test Coverage Report Link to Github Actions Job Summary
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: echo -e "Test Coverage Report https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' Github Actions Hob has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY
+          pwd
+          ls
+          cd /usr/
+          pwd
+          ls
+ 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,7 +51,7 @@ jobs:
           go-version-file: './go.mod'
           cache: true
 
-      - name: Buffalo - Get Previously Cached Install & Dependencies
+      - name: Buffalo - Get Previously Cached Install
         # cache is automatically saved after this job completes
         id: buffalo-cache-step
         uses: actions/cache@v3
@@ -67,8 +67,17 @@ jobs:
           tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
           sudo mv buffalo /usr/local/bin/buffalo
 
+      - name: Buffalo - Get Previously Cached Dependencies
+        # cache is automatically saved after this job completes
+        id: buffalo-cache-dependencies-step
+        uses: actions/cache@v3
+        with:
+          # buffalo-pop plugin in /go/bin/ folder
+          path: '/home/runner/go/bin'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
+
       - name: Install Buffalo pop plugin
-        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
+        if: steps.buffalo-cache-dependencies-step.outputs.cache-hit != 'true'
         run: buffalo plugins install
 
       - name: bin

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   # Label of the container job
-  dependencies:
+  paphos-backend-tests:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,7 +9,6 @@ on:
   workflow_dispatch:   
 
 env:
-  go-version: '1.19.1'
   buffalo-cli-version: '0.18.13'
   #PostgreSQL Credentials
   PGUSER: paphos
@@ -51,16 +50,26 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{  env.go-version  }}
-          cache: true
+          go-version-file: './go.mod'
+          cache: true # Caches Go dependencies
+
+      - name: Get Previously Cache Dependencies
+        # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
+        id: buffalo-cache-step
+        uses: actions/cache@v3
+        with:
+          path: '**/usr/local/bin/buffalo'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo
+        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/gobuffalo/cli/releases/download/v0.18.13/buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
           tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
           sudo mv buffalo /usr/local/bin/buffalo
           
       - name: Install Buffalo pop plugin
+        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
         run: buffalo plugins install
 
       - name: Go Version

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -90,10 +90,12 @@ jobs:
           path: coverage_report.html
 
       - name: Install Pandoc
+        if: success() || failure() # Always run, including if earlier steps failed
         # required to convert the report from HTML to Markdown for pretty embedding in the Job Summary
         run: sudo apt-get install pandoc
 
       - name: Convert Coverage Report HTML to Markdown
+        if: success() || failure() # Always run, including if earlier steps failed
         run: pandoc --from html --to markdown coverage_report.html -o coverage_report.md
 
       - name: Write Coverage Report to Github Actions Job Summary

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -111,4 +111,4 @@ jobs:
 
       - name: Add Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  (NOTE - This link will not work until the 'pages build and deployment' job has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY
+        run: echo -e "Coverage Report Link https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' job has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,27 +45,18 @@ jobs:
           ref: gh-pages
           path: public
 
-      - name: Cache Go Install & Dependencies
-        uses: actions/cache@v3
-        id: go-cache-step
-        with:
-          path: |
-            '**/usr/local/go'
-            '$GOPATH/pkg/mod'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
-
       - name: Install Go
-        if: steps.go-cache-step.outputs.cache-hit != 'true'
         uses: actions/setup-go@v3
         with:
           go-version-file: './go.mod'
+          cache: true
 
       - name: Buffalo - Get Previously Cached Install & Dependencies
         # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
         id: buffalo-cache-step
         uses: actions/cache@v3
         with:
-          path: '**/usr/local/bin/buffalo'
+          path: '/home/runner/bin/buffalo'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Checkout tools repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{  github.repository_owner  }}/gh-pages
+          path: public
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
@@ -105,4 +111,4 @@ jobs:
 
       - name: Add Coverage Report Link to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/paphos-backend/${{  github.run_number  }}/#file0  (NOTE - This link will not work until the 'pages build and deployment' job has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY
+        run: echo "Coverage Report Link https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  (NOTE - This link will not work until the 'pages build and deployment' job has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,3 +64,14 @@ jobs:
       
       - name: Buffalo Pop - Create Database
         run: buffalo pop create -a
+
+      - name: Buffalo Build
+        run: buffalo build
+
+      - name: Buffalo Tests
+        run: buffalo test
+
+      - name: Coverage Report
+        # Always run, including if the previous 'Buffalo Tests' step fails
+        if: success() || failure()
+        run: echo 'rawr!'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,4 +91,4 @@ jobs:
 
       - name: Write to Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: cat coverage_report.html >> $GITHUB_STEP_SUMMARY
+        run: links coverage_report.html >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,7 +60,6 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo
-        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/gobuffalo/cli/releases/download/v0.18.13/buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
           tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
@@ -75,7 +74,7 @@ jobs:
           ls
         
       - name: plugin-path
-        run: echo "$BUFFALO_PLUGIN_PATH"
+        run: echo $BUFFALO_PLUGIN_PATH
 
       - name: gopath-bin
-        run: echo "$GOPATH/bin"
+        run: echo $GOPATH/bin

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -98,7 +98,7 @@ jobs:
         if: success() || failure() # Always run, including if earlier steps failed
         run: |
           mkdir public
-          mv coverage_report.html ./public/coverage_report.html
+          mv coverage_report.html ./public/index.html
           cd public
           ls
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -66,21 +66,51 @@ jobs:
           tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
           sudo mv buffalo /usr/local/bin/buffalo
 
-      - name: test
-        run: |
-          cd /opt/hostedtoolcache/
-          pwd
-          ls
+      - name: Install Buffalo pop plugin
+        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
+        run: buffalo plugins install
 
-      - name: test2
-        run: |
-          cd /usr/local/
-          pwd
-          ls
+      - name: Buffalo Pop - Create Database
+        run: buffalo pop create -a
 
-      - name: test3
+      - name: Buffalo Build
+        run: buffalo build
+
+      - name: Buffalo Tests / Generate Coverage Report
+        run: buffalo test -coverprofile=c.out ./...
+
+      - name: Convert Test Coverage Report to be Human Readable
+        if: success() || failure() # Always run, including if earlier steps failed
+        run: go tool cover -html c.out -o coverage_report.html
+
+      - name: Upload Test Coverage Report as Artifact
+        if: success() || failure() # Always run, including if earlier steps failed
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-coverage-report
+          path: ./coverage_report.html
+
+      - name: Add Test Coverage Pull Request Comment (if on PR)
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request' && (success() || failure())
+        with:
+          recreate: true
+          path: coverage_report.html
+
+      - name: Move Test Coverage Report HTML to directory to publish on 'gh-pages' Branch (Github Pages)
+        if: success() || failure() # Always run, including if earlier steps failed
         run: |
-          cd /usr/local/bin/
-          pwd
-          ls
- 
+          mkdir -p public/${{  github.run_number  }}
+          mv coverage_report.html ./public/${{  github.run_number  }}/index.html
+
+      - name: Add Test Coverage Report Artifact to 'gh-pages' Branch (Github Pages)
+        if: success() || failure() # Always run, including if earlier steps failed
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: public
+          branch: gh-pages
+          force: false
+
+      - name: Add Test Coverage Report Link to Github Actions Job Summary
+        if: success() || failure() # Always run, including if earlier steps failed
+        run: echo -e "Test Coverage Report https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' Github Actions Hob has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,7 +69,7 @@ jobs:
         run: buffalo build
 
       - name: Buffalo Tests
-        run: buffalo test -coverprofile=CoverageReport.out
+        run: buffalo test
 
       - name: Coverage Report
         # Always run. Including if the previous 'tests' step fails

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,6 +95,7 @@ jobs:
         run: coverage_report.html >> $GITHUB_STEP_SUMMARY
 
       - name: HTML Preview
+        if: success() || failure() # Always run, including if earlier steps failed
         id: html_preview
         uses: pavi2410/html-preview-action@v2
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,19 +75,54 @@ jobs:
           path: '/home/runner/go/bin'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
 
-      - name: Install Buffalo pop plugin
+      - name: Install Buffalo pop Plugin
         if: steps.buffalo-cache-dependencies-step.outputs.cache-hit != 'true'
         run: buffalo plugins install
 
-      - name: bin
+      - name: Buffalo Pop - Create Database
+        run: buffalo pop create -a
+
+      - name: Buffalo Pop - Apply Migrations
+        run: buffalo pop migrate
+
+      - name: Buffalo Build
+        run: buffalo build
+
+      - name: Buffalo Tests / Generate Coverage Report
+        run: buffalo test -coverprofile=c.out ./...
+
+      - name: Convert Test Coverage Report to be Human Readable
+        if: success() || failure() # Always run, including if earlier steps failed
+        run: go tool cover -html c.out -o coverage_report.html
+
+      - name: Upload Test Coverage Report as Artifact
+        if: success() || failure() # Always run, including if earlier steps failed
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-coverage-report
+          path: ./coverage_report.html
+
+      - name: Add Test Coverage Pull Request Comment (if on PR)
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request' && (success() || failure())
+        with:
+          recreate: true
+          path: coverage_report.html
+
+      - name: Move Test Coverage Report HTML to directory to publish on 'gh-pages' Branch (Github Pages)
+        if: success() || failure() # Always run, including if earlier steps failed
         run: |
-          cd /usr/local/bin
-          pwd
-          ls
+          mkdir -p public/${{  github.run_number  }}
+          mv coverage_report.html ./public/${{  github.run_number  }}/index.html
 
-      - name: find
-        run: find ~/ -type f -name "buffalo-pop"
+      - name: Add Test Coverage Report Artifact to 'gh-pages' Branch (Github Pages)
+        if: success() || failure() # Always run, including if earlier steps failed
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: public
+          branch: gh-pages
+          force: false
 
-
-      - name: test
-        run: buffalo plugins list
+      - name: Add Test Coverage Report Link to Github Actions Job Summary
+        if: success() || failure() # Always run, including if earlier steps failed
+        run: echo -e "Test Coverage Report https://${{  github.repository_owner  }}.github.io/${{  github.event.repository.name  }}/${{  github.run_number  }}/#file0  \n(NOTE - This link will not work until the 'pages build and deployment' Github Actions Hob has completed. This typically takes around 1 minute)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,6 +60,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo
+        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/gobuffalo/cli/releases/download/v0.18.13/buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
           tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
@@ -69,12 +70,4 @@ jobs:
         run: buffalo plugins install
 
       - name: test
-        run: |
-          pwd
-          ls
-        
-      - name: plugin-path
-        run: echo $BUFFALO_PLUGIN_PATH
-
-      - name: gopath-bin
-        run: echo $GOPATH/bin
+        run: buffalo plugins list

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,11 +47,13 @@ jobs:
           ref: gh-pages
           path: public
 
-      - name: Cache Go Install
+      - name: Cache Go Install & Dependencies
         uses: actions/cache@v3
         id: go-cache-step
         with:
-          path: '**/usr/local/go'
+          path: |
+            '**/usr/local/go'
+            '$GOPATH/pkg/mod'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
 
       - name: Install Go
@@ -59,7 +61,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: './go.mod'
-          cache: true # Caches Go dependencies
 
       - name: Buffalo - Get Previously Cached Install & Dependencies
         # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
@@ -85,6 +86,21 @@ jobs:
 
       - name: Buffalo Version
         run: buffalo version
+
+      - name: Buffalo - save
+        # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
+        uses: actions/cache/save@v3
+        with:
+          path: '**/usr/local/bin/buffalo'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
+
+      - name: Go Save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            '**/usr/local/go'
+            '$GOPATH/pkg/mod'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
       
       - name: Buffalo Pop - Create Database
         run: buffalo pop create -a

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,9 +51,36 @@ jobs:
           go-version-file: './go.mod'
           cache: true
 
+      - name: Buffalo - Get Previously Cached Install & Dependencies
+        # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
+        id: buffalo-cache-step
+        uses: actions/cache@v3
+        with:
+          path: '/usr/local/bin/buffalo'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
+        
+      - name: Install Buffalo
+        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
+        run: |
+          wget https://github.com/gobuffalo/cli/releases/download/v0.18.13/buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
+          tar -xvzf buffalo_${{  env.buffalo-cli-version  }}_Linux_x86_64.tar.gz
+          sudo mv buffalo /usr/local/bin/buffalo
+
       - name: test
         run: |
           cd /opt/hostedtoolcache/
+          pwd
+          ls
+
+      - name: test2
+        run: |
+          cd /usr/local/
+          pwd
+          ls
+
+      - name: test3
+        run: |
+          cd /usr/local/bin/
           pwd
           ls
  

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,13 +89,13 @@ jobs:
         # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
         uses: actions/cache/save@v3
         with:
-          path: '~/usr/local/bin/buffalo'
+          path: '${{ github.workspace }}/usr/local/bin/buffalo'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
 
       - name: Go Save
         uses: actions/cache/save@v3
         with:
-          path: '~/usr/local/go'
+          path: '${{ github.workspace }}/usr/local/go'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/go.mod') }}
       
       - name: Buffalo Pop - Create Database

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,9 +56,10 @@ jobs:
         id: buffalo-cache-step
         uses: actions/cache@v3
         with:
+          # buffalo-pop plugin in /go/bin/ folder
           path: |
             '/usr/local/bin/buffalo'
-            '/home/runner/go/bin/buffalo-pop'
+            '/home/runner/go/bin'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,9 +69,9 @@ jobs:
         run: buffalo build
 
       - name: Buffalo Tests
-        run: buffalo test
+        run: buffalo test -coverprofile=c.out ./...
 
       - name: Coverage Report
         # Always run. Including if the previous 'tests' step fails
         if: success() || failure()
-        run: cat CoverageReport.out
+        run: ls

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,7 @@
 name: Pygmalion Paphos Back End
 
 permissions:
-  # Read is required for actions/checkout / Write is required for publishing to Github Pages
+  # Read is required for actions/checkout / Write is required for publishing test report artifact to Github Pages
   contents: write
 
 on:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,7 +56,6 @@ jobs:
         id: buffalo-cache-step
         uses: actions/cache@v3
         with:
-          # buffalo-pop plugin in /go/bin/ folder
           path: '/usr/local/bin/buffalo'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,11 +89,13 @@ jobs:
           recreate: true
           path: coverage_report.html
 
-      - name: Install Links
-        # This is required to correctly display the HTML of the Coverage Report
-        if: success() || failure() # Always run, including if earlier steps failed
-        run: sudo apt-get install links
+      - name: Install Pandoc
+        # required to convert the report from HTML to Markdown for pretty embedding in the Job Summary
+        run: sudo apt-get install pandoc
+
+      - name: Convert Coverage Report HTML to Markdown
+        run: pandoc --from html --to markdown coverage_report.html -o coverage_report.md
 
       - name: Write Coverage Report to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
-        run: links coverage_report.html >> $GITHUB_STEP_SUMMARY
+        run: cat coverage_report.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -93,3 +93,9 @@ jobs:
       - name: Write Coverage Report to Github Actions Job Summary
         if: success() || failure() # Always run, including if earlier steps failed
         run: coverage_report.html >> $GITHUB_STEP_SUMMARY
+
+      - name: HTML Preview
+        id: html_preview
+        uses: pavi2410/html-preview-action@v2
+        with:
+          html_file: 'coverage_report.html'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,8 +1,8 @@
 name: Pygmalion Paphos Back End
 
 permissions:
-  contents: read # This is required for actions/checkout
-  contents: write # This is required to publish to Github Pages
+  # Read is required for actions/checkout / Write is required for publishing to Github Pages
+  contents: read, write
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,7 +2,7 @@ name: Pygmalion Paphos Back End
 
 permissions:
   # Read is required for actions/checkout / Write is required for publishing to Github Pages
-  contents: read, write
+  contents: write
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -57,9 +57,7 @@ jobs:
         uses: actions/cache@v3
         with:
           # buffalo-pop plugin in /go/bin/ folder
-          path: |
-            '/usr/local/bin/buffalo'
-            '/home/runner/go/bin'
+          path: '/usr/local/bin/buffalo'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/config/buffalo-plugins.toml') }}
         
       - name: Install Buffalo

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,11 +95,13 @@ jobs:
         run: coverage_report.html >> $GITHUB_STEP_SUMMARY
 
       - name: Move Report HTML to directory to publish on Github Pages
+        if: success() || failure() # Always run, including if earlier steps failed
         run: |
           mkdir public
           mv coverage_report.html ./public/coverage_report.html
 
       - name: "Publish test results"
+        if: success() || failure() # Always run, including if earlier steps failed
         uses: peaceiris/actions-gh-pages@v3.9.2
         with: 
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -81,3 +81,13 @@ jobs:
         with:
           name: test-coverage-report
           path: ./coverage_report.html
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: coverage_report.html
+
+      - name: Write to Job Summary
+        run: cat coverage_report.html >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,5 +69,12 @@ jobs:
       - name: Install Buffalo pop plugin
         run: buffalo plugins install
 
+      - name: bin
+        run: |
+          cd /usr/local/bin
+          pwd
+          ls
+
+
       - name: test
         run: buffalo plugins list

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,10 +68,5 @@ jobs:
       - name: Buffalo Build
         run: buffalo build
 
-      - name: Buffalo Tests
+      - name: Buffalo Tests / Coverage
         run: buffalo test -coverprofile=c.out ./...
-
-      - name: Coverage Report
-        # Always run. Including if the previous 'tests' step fails
-        if: success() || failure()
-        run: ls

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,6 +83,7 @@ jobs:
           path: ./coverage_report.html
 
       - name: Add Coverage PR Comment
+        if: success() || failure() # Always run, including if earlier steps failed
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:
@@ -90,4 +91,5 @@ jobs:
           path: coverage_report.html
 
       - name: Write to Job Summary
+        if: success() || failure() # Always run, including if earlier steps failed
         run: cat coverage_report.html >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,9 +72,11 @@ jobs:
         run: buffalo test -coverprofile=c.out ./...
 
       - name: Convert Coverage Report to be Human Readable
+        if: success() || failure() # Always run, including if earlier steps failed
         run: go tool cover -html c.out -o coverage_report.html
 
       - name: Upload Coverage Report as Artifact
+        if: success() || failure() # Always run, including if earlier steps failed
         uses: actions/upload-artifact@v3
         with:
           name: test-coverage-report

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,8 +1,8 @@
 name: Pygmalion Paphos Back End
 
 permissions:
-  # This is required for actions/checkout
-  contents: read 
+  contents: read # This is required for actions/checkout
+  contents: write # This is required to publish to Github Pages
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: test
         run: |
-          cd /usr/local
+          cd /opt/hostedtoolcache/
           pwd
           ls
  

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -94,9 +94,14 @@ jobs:
         if: success() || failure() # Always run, including if earlier steps failed
         run: coverage_report.html >> $GITHUB_STEP_SUMMARY
 
-      - name: HTML Preview
-        if: success() || failure() # Always run, including if earlier steps failed
-        id: html_preview
-        uses: pavi2410/html-preview-action@v2
-        with:
-          html_file: 'coverage_report.html'
+      - name: Move Report HTML to directory to publish on Github Pages
+        run: |
+          mkdir public
+          mv coverage_report.html ./public/coverage_report.html
+
+      - name: "Publish test results"
+        uses: peaceiris/actions-gh-pages@v3.9.2
+        with: 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,7 +52,7 @@ jobs:
           cache: true
 
       - name: Buffalo - Get Previously Cached Install & Dependencies
-        # cache is automatically saved after this job completes. jobs depending on this one will get the latest cached files
+        # cache is automatically saved after this job completes
         id: buffalo-cache-step
         uses: actions/cache@v3
         with:
@@ -67,11 +67,13 @@ jobs:
           sudo mv buffalo /usr/local/bin/buffalo
 
       - name: Install Buffalo pop plugin
-        if: steps.buffalo-cache-step.outputs.cache-hit != 'true'
         run: buffalo plugins install
 
       - name: Buffalo Pop - Create Database
         run: buffalo pop create -a
+
+      - name: Buffalo Pop - Apply Migrations
+        run: buffalo pop migrate
 
       - name: Buffalo Build
         run: buffalo build

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,5 +68,14 @@ jobs:
       - name: Buffalo Build
         run: buffalo build
 
-      - name: Buffalo Tests / Coverage
+      - name: Buffalo Tests / Generate Coverage Report
         run: buffalo test -coverprofile=c.out ./...
+
+      - name: Convert Coverage Report to be Human Readable
+        run: go tool cover -html c.out -o coverage_report.html
+
+      - name: Upload Coverage Report as Artifact
+        uses: actions/upload-artifact@v3
+          with:
+            name: test-coverage-report
+            path: ./coverage_report.html


### PR DESCRIPTION
installs & caches dependencies
runs tests
stores test results as an artifact & on github pages for ease of viewing. URL to this is attached when the GithubAction is run

Note: This requires some changes at the Github Repository level to enable Github Pages
github.com/<GITHUB ORG>/paphos-backend/settings/pages

set to 'deploy from branch'
using branch: 'gh-pages' on folder '/ (root)'

![image](https://user-images.githubusercontent.com/59989569/216809578-be318557-f15a-4e32-b559-0a4a466d00ba.png)
